### PR TITLE
A DataView is returned instead of an ArrayBuffer in M50.

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -165,8 +165,9 @@
 
             // so now we have the characteristic and we can keep reading data...
             function readZ() {
-              char.readValue().then(buffer => {
-                var data = new DataView(buffer);
+              char.readValue().then(data => {
+                // In Chrome 50+, a DataView is returned instead of an ArrayBuffer.
+                data = data.buffer ? data : new DataView(data);
 
                 var z = data.getUint8(5) << 8 | data.getUint8(4);
                 if (z > 32767) { // overflow


### PR DESCRIPTION
As you can read at https://github.com/WebBluetoothCG/web-bluetooth/pull/201, a `DataView` is  now returned instead of an `ArrayBuffer` when reading values.
You can remove this check when Chrome 50 reaches Stable channel.
